### PR TITLE
bugfix: version 1.0 changed save file folder and name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.sav
+SaveData

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ Tiny NodeJS application to fiddle with the game save files.
 ## Instructions
 
 1) Either disable Steam cloud saves for the game, or in case of conflict, always choose local files
-2) Drop this file into the game's save folder (https://www.pcgamingwiki.com/wiki/Vampire_Survivors#Save_game_data_location)
+2) Drop this file into the game's save folder. For versions prior to `1.0`, check [PCGamingWiki](https://www.pcgamingwiki.com/wiki/Vampire_Survivors#Save_game_data_location); for the current version, check *Method 2* folder location of [this Steam Guide](https://steamcommunity.com/sharedfiles/filedetails/?id=2847140637).
 3) Run the file from a command line (`node vs-savegame-editor.js`)
 4) Run the game. If coins are not changed, reset your power-ups
 
-You can edit the amount of coins that will be set by editing the `newCoinsAmount` constant at the beginning of `vs-savegame-editor.js`. Note that the script sets the current amount of coins to this value, but adds to the "lifetime coins" total, so if you reset your powerups you recover the lifetime amount.
+You can edit the amount of coins that will be set by editing the `NEW_COINS_AMOUNT` constant at the beginning of `vs-savegame-editor.js`. Note that the script sets the current amount of coins to this value, but adds to the "lifetime coins" total, so if you reset your powerups you recover the lifetime amount.
 
-It creates a backup copy of the original save file on each run, but still no responsibilites if it messes up things!
+Note that after editing the file, Steam can warn you about a cloud sync conflict. This is fine and you should tell it to keep your local file (with newer modification date).
+
+Tested on Windows. Creates a backup copy of the original save file on each run, but still no responsibilites if it messes up things!

--- a/vs-savegame-editor.js
+++ b/vs-savegame-editor.js
@@ -3,20 +3,30 @@ const fs = require("fs");
 const path = require("path");
 
 // This is the amount of coins that will be added to the save game
-const newCoinsAmount = 500000;
+const NEW_COINS_AMOUNT = 500000;
 
 // Useful for when you want to change other parameters of the save file by yourself, and still want to have a valid
 // checksum generated at the end
-const skipChecksum = false;
+const SKIP_CHECKSUM = false;
 
-const loadSaveData = () => {
-  const fileName = "SaveData.sav";
-  const filePath = path.join(process.cwd(), fileName);
-  if (fs.existsSync(filePath)) {
-    return JSON.parse(fs.readFileSync(filePath, "utf8"));
-  } else {
-    throw new Error(`File '${fileName}' not found`);
+const SAVE_FILENAME = "SaveData";
+const SAVE_FILENAME_OLD = "SaveData.sav";
+
+const isOldFileName = () => {
+  if (fs.existsSync(path.join(process.cwd(), SAVE_FILENAME_OLD))) {
+    return true;
   }
+  if (fs.existsSync(path.join(process.cwd(), SAVE_FILENAME))) {
+    return false;
+  }
+  throw new Error(
+    `Save file not found, attempted with filenames: ${SAVE_FILENAME}, ${SAVE_FILENAME_OLD}`
+  );
+};
+
+const loadSaveData = (fileName) => {
+  const filePath = path.join(process.cwd(), fileName);
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
 };
 
 const saveDataToFile = (saveData, fileName) => {
@@ -33,17 +43,22 @@ const calculateChecksum = (jsonObject) =>
     .update(JSON.stringify(jsonObject))
     .digest("hex");
 
-const validateChecksum = (saveData) => {
+const isChecksumValid = (saveData) => {
   const saveDataCopy = copyData(saveData);
   saveDataCopy["checksum"] = "";
 
   return calculateChecksum(saveDataCopy) === saveData["checksum"];
 };
 
-const changeAvailableCoins = (saveData, desiredAmount) => {
+const changeAvailableCoins = (fileName, saveData, desiredAmount) => {
   const saveDataCopy = copyData(saveData);
 
-  const backupFileName = `SaveData_Backup_${Date.now()}.sav`;
+  const backupFileNameWithoutExt = fileName.split(".")[0];
+  const backupFileExtension = fileName.split(".")[1] || "";
+  const backupFileName = `${backupFileNameWithoutExt}_Backup_${Date.now()}${
+    backupFileExtension ? `.${backupFileExtension}` : ""
+  }`;
+
   saveDataToFile(saveDataCopy, backupFileName);
   console.log(`Original game backup saved as '${backupFileName}'`);
 
@@ -56,17 +71,20 @@ const changeAvailableCoins = (saveData, desiredAmount) => {
 
   saveDataCopy["checksum"] = calculateChecksum(saveDataCopy);
 
-  const fileName = "SaveData.sav";
   saveDataToFile(saveDataCopy, fileName);
   console.log(`Modified game saved as '${fileName}'`);
 };
 
 // ---
 
-let saveGameData = loadSaveData();
-if (!skipChecksum) {
-  console.log("checksum correct?", validateChecksum(saveGameData));
+let fileName = isOldFileName() ? SAVE_FILENAME_OLD : SAVE_FILENAME;
+
+let saveGameData = loadSaveData(fileName);
+let validChecksum = isChecksumValid(saveGameData);
+
+if (!SKIP_CHECKSUM) {
+  console.log("checksum correct?", validChecksum);
 }
-if (skipChecksum || validateChecksum(saveGameData)) {
-  changeAvailableCoins(saveGameData, newCoinsAmount);
+if (validChecksum || SKIP_CHECKSUM) {
+  changeAvailableCoins(fileName, saveGameData, NEW_COINS_AMOUNT);
 }


### PR DESCRIPTION
Fixes https://github.com/Kartones/vampire-survivors-savegame-editor/issues/4

Version 1.0 of the game introduced another save location change (and in this case filename changed too, now without `.sav` extension).

Now the script attempts to find both old and new filenames, and supports backing up both. 


Steam might give a warning about sync:
![image](https://user-images.githubusercontent.com/2085449/208367501-50882f6d-3be8-494f-851d-0515fe9b2062.png)

But all is fine and works:
![image](https://user-images.githubusercontent.com/2085449/208367528-3df85c27-b8b1-4645-b591-acd37f7e9fa8.png)
